### PR TITLE
JSON-Array.js -- upstream & optimizations and changes

### DIFF
--- a/Gallery Files/Extension-Keys.json
+++ b/Gallery Files/Extension-Keys.json
@@ -33,6 +33,7 @@
       "url": "extension-code/Scratch-Utilities.js",
       "banner": "extension-thumbs/Scratch-Utilities.svg",
       "tags": ["all", "expanded", "fetching"],
+      "isDeprecated": true,
       "status": "",
       "date": "Last Updated: 04/05/2024"
     },
@@ -52,7 +53,7 @@
       "banner": "extension-thumbs/Tune-Shark-V3.svg",
       "tags": ["all", "utilities", "expanded", "category"],
       "status": "",
-      "date": "Last Updated: 05/17/2025"
+      "date": "Last Updated: 06/21/2025"
     },
     "Tune-Shark": {
       "desc": "Outdated Sound Engine for playing sounds. Please use Tune Shark V3",
@@ -88,17 +89,17 @@
       "url": "extension-code/Sound-Waves.js",
       "banner": "extension-thumbs/Sound-Waves.svg",
       "tags": ["all", "utilities"],
-      "status": "",
-      "date": "Last Updated: 04/10/2025"
+      "status": "update",
+      "date": "Last Updated: 06/29/2025"
     },
     "Hyper-Sense": {
       "desc": "New Sensing Blocks",
       "creator": "SharkPool",
-      "url": "extension-code/Hyper-Sense.js",
+      "url": "extension-code/Hyper-Sense-V2.js",
       "banner": "extension-thumbs/Hyper-Sense.svg",
       "tags": ["all", "utilities", "expanded", "category"],
-      "status": "update",
-      "date": "Last Updated: 05/27/2025"
+      "status": "new",
+      "date": "Re-Released: 06/23/2025"
     },
     "Keys-Plus-V2": {
       "desc": "Powerful and flexible Key detection Blocks with some additional features",
@@ -116,7 +117,7 @@
       "banner": "extension-thumbs/Popup-Phoenix.svg",
       "tags": ["all", "utilities", "expanded"],
       "status": "",
-      "date": "Released: 02/19/2025"
+      "date": "Last Updated: 06/01/2025"
     },
     "Better-Input": {
       "desc": "Expansion of the 'Ask and Wait' Block. Deprecated, please use Popup-Phoenix",
@@ -163,7 +164,7 @@
       "banner": "extension-thumbs/Looks-Expanded.svg",
       "tags": ["all", "utilities", "expanded", "category"],
       "status": "",
-      "date": "Last Updated: 05/03/2025"
+      "date": "Last Updated: 06/03/2025"
     },
     "Sprite-Effects": {
       "desc": "Apply Effects and Filters to SVGs, Sprites, and the Canvas! Faster than Image Effects",
@@ -251,9 +252,9 @@
       "creator": "SharkPool, Drago Cuven, 0znzw",
       "url": "extension-code/Files-Expanded.js",
       "banner": "extension-thumbs/Files-Expanded.svg",
-      "tags": ["all", "expanded", "fetching"],
+      "tags": ["all", "expanded"],
       "status": "",
-      "date": "Last Updated: 02/01/2025"
+      "date": "Last Updated: 06/07/2025"
     },
     "Temporary-Variables": {
       "desc": "Create Temporary Variables for Sprites, Threads, and the Project",
@@ -415,7 +416,7 @@
       "banner": "extension-thumbs/Display-Text.svg",
       "tags": ["all", "expanded", "utilities", "category"],
       "status": "",
-      "date": "Last Updated: 05/02/2025"
+      "date": "Last Updated: 06/12/2025"
     },
     "Color-Master": {
       "desc": "Color Utility and Conversion Blocks",
@@ -469,7 +470,7 @@
       "banner": "extension-thumbs/Script-Control.svg",
       "tags": ["all", "utilities"],
       "status": "",
-      "date": "Last Updated: 05/04/2025"
+      "date": "Last Updated: 05/30/2025"
     },
     "Layer-Control": {
       "desc": "Relayer Pen, Video Camera, Backdrops, Sprites and more",
@@ -594,8 +595,8 @@
       "url": "extension-code/JSON-Array.js",
       "banner": "extension-thumbs/JSON-Array.svg",
       "tags": ["all", "utilities", "expanded"],
-      "status": "",
-      "date": "Last Updated: 04/21/2025"
+      "status": "update",
+      "date": "Last Updated: 06/29/2025"
     },
     "My-Blocks-Plus": {
       "desc": "Better Custom Blocks",
@@ -604,7 +605,7 @@
       "banner": "extension-thumbs/My-Blocks-Plus.svg",
       "tags": ["all", "utilities", "expanded", "category"],
       "status": "",
-      "date": "Last Updated: 05/04/2025"
+      "date": "Last Updated: 06/09/2025"
     },
     "Dropdown-Maker": {
       "desc": "Create Custom Dropdowns! Best paired with My Blocks+",
@@ -625,13 +626,13 @@
       "date": "Last Updated: 05/17/2025"
     },
     "Scenes": {
-      "desc": "Create Scenes, like Unity, in your Project",
+      "desc": "Create Scenes (savestates), like Unity, in your Project",
       "creator": "SharkPool",
       "url": "extension-code/Scenes.js",
       "banner": "extension-thumbs/Scenes.svg",
       "tags": ["all", "utilities", "addon"],
       "status": "",
-      "date": "Last Updated: 02/01/2025"
+      "date": "Last Updated: 06/12/2025"
     },
     "Pen-Papers": {
       "desc": "Create Multiple Pen Layers! Inspired by ObviousAlex",

--- a/extension-code/JSON-Array.js
+++ b/extension-code/JSON-Array.js
@@ -424,6 +424,7 @@
           {
             opcode: "jsonBuilder",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "{ [KEY] : [VAL] }",
             arguments: {
               KEY: { type: Scratch.ArgumentType.STRING, defaultValue: "key" },
@@ -434,6 +435,7 @@
           {
             opcode: "getKey",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "get [KEY] from [OBJ]",
             arguments: {
               KEY: { type: Scratch.ArgumentType.STRING, defaultValue: "key" },
@@ -443,6 +445,7 @@
           {
             opcode: "getPath",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "get path [PATH] from [OBJ]",
             arguments: {
               PATH: { type: Scratch.ArgumentType.STRING, defaultValue: `["key", "value1"]`, exemptFromNormalization: true },
@@ -452,6 +455,7 @@
           {
             opcode: "setKey",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "set [KEY] to [VAL] in [OBJ]",
             arguments: {
               KEY: { type: Scratch.ArgumentType.STRING, defaultValue: "key" },
@@ -462,6 +466,7 @@
           {
             opcode: "setPath",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "set path [PATH] to [VAL] in [OBJ]",
             arguments: {
               PATH: { type: Scratch.ArgumentType.STRING, defaultValue: `["key1", "key2"]`, exemptFromNormalization: true },
@@ -472,6 +477,7 @@
           {
             opcode: "deleteKey",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "delete [KEY] from [OBJ]",
             arguments: {
               KEY: { type: Scratch.ArgumentType.STRING, defaultValue: "key" },
@@ -491,7 +497,6 @@
             opcode: "keyIndex",
             blockType: Scratch.BlockType.REPORTER,
             text: "index of [KEY] in [OBJ]",
-            allowDropAnywhere: true,
             arguments: {
               KEY: { type: Scratch.ArgumentType.STRING, defaultValue: "key" },
               OBJ: { type: Scratch.ArgumentType.STRING, defaultValue: `{"key":"value"}`, exemptFromNormalization: true }
@@ -500,6 +505,7 @@
           {
             opcode: "getEntry",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "get [KEY] entry from [OBJ]",
             arguments: {
               KEY: { type: Scratch.ArgumentType.STRING, defaultValue: "key" },
@@ -509,6 +515,7 @@
           {
             opcode: "extractJson",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "all [TYPE] from [OBJ]",
             arguments: {
               TYPE: { type: Scratch.ArgumentType.STRING, menu: "OBJ_EXTRACT" },
@@ -518,6 +525,7 @@
           {
             opcode: "mergeJson",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "merge [OBJ1] and [OBJ2]",
             arguments: {
               OBJ1: { type: Scratch.ArgumentType.STRING, defaultValue: `{"key":"value"}`, exemptFromNormalization: true },
@@ -526,7 +534,7 @@
           },
           "---",
           {
-            opcode: "jsonMap", blockType: Scratch.BlockType.REPORTER,
+            opcode: "jsonMap", blockType: Scratch.BlockType.REPORTER, allowDropAnywhere: true,
             text: "map [OBJ] using rule [IND] [VAL] [IMG] [VALUE]", hideFromPalette: true,
             arguments: {
               OBJ: { type: Scratch.ArgumentType.STRING, exemptFromNormalization: true },
@@ -558,6 +566,7 @@
             opcode: "arrBuilder",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "［ [VAL] ］",
             arguments: {
               VAL: { type: Scratch.ArgumentType.STRING, defaultValue: "value", exemptFromNormalization: true }
@@ -568,6 +577,7 @@
             opcode: "arrAdd",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "add [ITEM] to [ARR]",
             arguments: {
               ITEM: { type: Scratch.ArgumentType.STRING, defaultValue: "thing", exemptFromNormalization: true },
@@ -578,6 +588,7 @@
             opcode: "arrInsert",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "insert [ITEM] at [IND] in [ARR]",
             arguments: {
               ITEM: { type: Scratch.ArgumentType.STRING, defaultValue: "b", exemptFromNormalization: true },
@@ -589,6 +600,7 @@
             opcode: "arrReplace",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "replace item [IND] with [ITEM] in [ARR]",
             arguments: {
               IND: { type: Scratch.ArgumentType.NUMBER, defaultValue: 1 },
@@ -600,6 +612,7 @@
             opcode: "arrSwap",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "swap item [IND1] with item [IND2] in [ARR]",
             arguments: {
               IND1: { type: Scratch.ArgumentType.NUMBER, defaultValue: 1 },
@@ -611,6 +624,7 @@
             opcode: "arrDelete",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "delete item [IND] in [ARR]",
             arguments: {
               IND: { type: Scratch.ArgumentType.NUMBER, defaultValue: 1 },
@@ -621,6 +635,7 @@
             opcode: "arrGet",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "item [IND] in [ARR]",
             arguments: {
               IND: { type: Scratch.ArgumentType.NUMBER, defaultValue: 1 },
@@ -631,6 +646,7 @@
             opcode: "arrSlice",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "items [IND1] to [IND2] in [ARR]",
             arguments: {
               IND1: { type: Scratch.ArgumentType.NUMBER, defaultValue: 2 },
@@ -681,6 +697,7 @@
             opcode: "itemIndex",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "index # [IND] of item [ITEM] in [ARR]",
             arguments: {
               IND: { type: Scratch.ArgumentType.NUMBER, defaultValue: 1 },
@@ -693,6 +710,7 @@
             opcode: "mergeArray",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "merge array [ARR1] and [ARR2]",
             arguments: {
               ARR1: { type: Scratch.ArgumentType.STRING, defaultValue: `["a", "b"]`, exemptFromNormalization: true },
@@ -703,6 +721,7 @@
             opcode: "repeatArray",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "repeat array [ARR] [NUM] times",
             arguments: {
               ARR: { type: Scratch.ArgumentType.STRING, defaultValue: `["a", "b"]`, exemptFromNormalization: true },
@@ -713,6 +732,7 @@
             opcode: "fillArray",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "fill array [ARR] to length [NUM]",
             arguments: {
               ARR: { type: Scratch.ArgumentType.STRING, defaultValue: `["a", "b"]`, exemptFromNormalization: true },
@@ -723,6 +743,7 @@
             opcode: "arrOrder",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "order [ARR] by [ORDERER]",
             arguments: {
               ARR: { type: Scratch.ArgumentType.STRING, defaultValue: `["2", "item1", "1", "item12", "1"]`, exemptFromNormalization: true },
@@ -731,7 +752,7 @@
           },
           "---",
           {
-            opcode: "arrCheck", blockType: Scratch.BlockType.BOOLEAN,
+            opcode: "arrCheck", blockType: Scratch.BlockType.BOOLEAN, allowDropAnywhere: true,
             text: "check [ARR] if [TYPE] item [IND] [VAL] [IMG] [BOOL]", hideFromPalette: true,
             arguments: {
               TYPE: { type: Scratch.ArgumentType.STRING, menu: "ARRAY_CHECK" },
@@ -742,7 +763,7 @@
           },
           {
             opcode: "arrMap", blockType: Scratch.BlockType.REPORTER, blockShape: Scratch.BlockShape.SQUARE,
-            text: "map [ARR] using rule [IND] [VAL] [IMG] [VALUE]", hideFromPalette: true,
+            text: "map [ARR] using rule [IND] [VAL] [IMG] [VALUE]", hideFromPalette: true, allowDropAnywhere: true,
             arguments: {
               ARR: { type: Scratch.ArgumentType.STRING, exemptFromNormalization: true },
               IND: {}, VAL: {},
@@ -762,7 +783,7 @@
           },
           {
             opcode: "arrSort", blockType: Scratch.BlockType.REPORTER, blockShape: Scratch.BlockShape.SQUARE,
-            text: "sort [ARR] using rule [A] [B] [IMG] [VALUE]", hideFromPalette: true,
+            text: "sort [ARR] using rule [A] [B] [IMG] [VALUE]", hideFromPalette: true, allowDropAnywhere: true,
             arguments: {
               ARR: { type: Scratch.ArgumentType.STRING, exemptFromNormalization: true },
               A: {}, B: {},
@@ -805,6 +826,7 @@
             opcode: "parse",
             blockType: Scratch.BlockType.REPORTER,
             text: "parse [OBJ]",
+            allowDropAnywhere: true,
             arguments: {
               OBJ: { type: Scratch.ArgumentType.STRING, defaultValue: `{"key": "value"}`, exemptFromNormalization: true }
             },
@@ -813,6 +835,7 @@
             opcode: "clone",
             blockType: Scratch.BlockType.REPORTER,
             text: "copy [OBJ] to new",
+            allowDropAnywhere: true,
             arguments: {
               OBJ: { type: Scratch.ArgumentType.STRING, defaultValue: `{"key": "value"}`, exemptFromNormalization: true }
             },
@@ -821,6 +844,7 @@
             opcode: "convert",
             blockType: Scratch.BlockType.REPORTER,
             text: "[OBJ] to [TYPE]",
+            allowDropAnywhere: true,
             arguments: {
               OBJ: { type: Scratch.ArgumentType.STRING, defaultValue: "{}", exemptFromNormalization: true },
               TYPE: { type: Scratch.ArgumentType.STRING, menu: "CONVERTS" }
@@ -830,6 +854,7 @@
           {
             opcode: "jsonMake",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "[TXT] split by [SPLIT] with delimiter [DELIM] to JSON",
             arguments: {
               TXT: { type: Scratch.ArgumentType.STRING, defaultValue: "a:1,b:2,c:3" },
@@ -841,6 +866,7 @@
             opcode: "arrMake",
             blockType: Scratch.BlockType.REPORTER,
             blockShape: Scratch.BlockShape.SQUARE,
+            allowDropAnywhere: true,
             text: "[TXT] split by [SPLIT] to [TYPE]",
             arguments: {
               TXT: { type: Scratch.ArgumentType.STRING, defaultValue: "a,b,c", exemptFromNormalization: true },
@@ -875,6 +901,7 @@
           },
           {
             opcode: "filterNew", blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "[TYPE] [OBJ] by [IND] [VAL] [IMG] [BOOL]", hideFromPalette: true,
             arguments: {
               TYPE: { type: Scratch.ArgumentType.STRING, menu: "CUST_ORDER" },
@@ -921,6 +948,7 @@
           {
             opcode: "rawVarValue",
             blockType: Scratch.BlockType.REPORTER,
+            allowDropAnywhere: true,
             text: "get raw [TYPE] named [NAME]",
             arguments: {
               TYPE: { type: Scratch.ArgumentType.STRING, menu: "VAR_TYPE" },

--- a/extension-code/JSON-Array.js
+++ b/extension-code/JSON-Array.js
@@ -623,7 +623,7 @@
             text: "[ARR] contains [ITEM] ?",
             arguments: {
               ARR: { type: Scratch.ArgumentType.STRING, defaultValue: `["a", "b", "c"]`, exemptFromNormalization: true },
-              ITEM: { type: Scratch.ArgumentType.STRING, defaultValue: "b" }
+              ITEM: { type: Scratch.ArgumentType.STRING, defaultValue: "b", exemptFromNormalization: true }
             },
           },
           {

--- a/extension-code/JSON-Array.js
+++ b/extension-code/JSON-Array.js
@@ -926,7 +926,7 @@
           ARRAY_CHECK: ["every", "some"],
           VAR_TYPE: ["variable", "list"],
           OBJ_EXTRACT: { acceptReporters: true, items: ["keys", "values"] },
-          CONVERTS: { acceptReporters: true, items: ["string", "array", "JSON"] },
+          CONVERTS: { acceptReporters: true, items: ["string", "pretty string", "array", "JSON"] },
           CONVERTS2: { acceptReporters: true, items: ["array", "text"] },
           SETTINGS: { acceptReporters: true, items: this.settings },
           ORDERING: {
@@ -1485,6 +1485,7 @@
       switch (args.TYPE) {
         case "array": return Object.entries(this.tryParse(args.OBJ));
         case "JSON": return Object.assign({}, this.tryParse(args.OBJ));
+        case "pretty string": return JSON.stringify(this.tryParse(args.OBJ), circularReplacer(), "\t");
         default: return JSON.stringify(this.tryParse(args.OBJ), circularReplacer());
       }
     }

--- a/extension-code/JSON-Array.js
+++ b/extension-code/JSON-Array.js
@@ -876,6 +876,26 @@
                 <value name="VAL"><shadow type="SPjson_objValue"></shadow></value>
               </block>`
           },
+          "---",
+          {
+            opcode: "setRawVarValue",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "set [TYPE] named [NAME] to [VALUE]",
+            arguments: {
+              TYPE: { type: Scratch.ArgumentType.STRING, menu: "VAR_TYPE" },
+              NAME: { type: Scratch.ArgumentType.STRING, defaultValue: "my variable" },
+              VALUE: { type: Scratch.ArgumentType.STRING, exemptFromNormalization: true }
+            },
+          },
+          {
+            opcode: "rawVarValue",
+            blockType: Scratch.BlockType.REPORTER,
+            text: "get raw [TYPE] named [NAME]",
+            arguments: {
+              TYPE: { type: Scratch.ArgumentType.STRING, menu: "VAR_TYPE" },
+              NAME: { type: Scratch.ArgumentType.STRING, defaultValue: "my variable" }
+            },
+          },
           { blockType: Scratch.BlockType.LABEL, text: "Safety Settings" },
           {
             func: "optimizeWarn",
@@ -904,6 +924,7 @@
           TOGGLER: ["enabled", "disabled"],
           CUST_ORDER: ["filter", "order"],
           ARRAY_CHECK: ["every", "some"],
+          VAR_TYPE: ["variable", "list"],
           OBJ_EXTRACT: { acceptReporters: true, items: ["keys", "values"] },
           CONVERTS: { acceptReporters: true, items: ["string", "array", "JSON"] },
           CONVERTS2: { acceptReporters: true, items: ["array", "text"] },
@@ -1571,6 +1592,36 @@
         util.thread.stackFrames[0].SPjson = entry[0];
       }
       util.startBranch(1, true);
+    }
+
+    setRawVarValue(args, util) {
+      const name = Cast.toString(args.NAME);
+      let variable, stage = runtime.getTargetForStage();
+      if (args.TYPE === "variable") {
+        variable = stage.lookupVariableByNameAndType(name, "");
+        if (!variable) variable = util.target.lookupVariableByNameAndType(name, "");
+
+        if (variable) variable.value = args.VALUE;
+      } else {
+        variable = stage.lookupVariableByNameAndType(name, "list");
+        if (!variable) variable = util.target.lookupVariableByNameAndType(name, "list");
+
+        if (variable && Array.isArray(args.VALUE)) variable.value = args.VALUE;
+      }
+    }
+
+    rawVarValue(args, util) {
+      const name = Cast.toString(args.NAME);
+      let variable, stage = runtime.getTargetForStage();
+      if (args.TYPE === "variable") {
+        variable = stage.lookupVariableByNameAndType(name, "");
+        if (!variable) variable = util.target.lookupVariableByNameAndType(name, "");
+      } else {
+        variable = stage.lookupVariableByNameAndType(name, "list");
+        if (!variable) variable = util.target.lookupVariableByNameAndType(name, "list");
+      }
+
+      return variable ? variable.value : "";
     }
   }
 


### PR DESCRIPTION
DO NOT MERGE UNTIL TURBOWARP HAS `BlockShape` (✅) AND UNTIL https://github.com/TurboWarp/scratch-gui/pull/1018 IS MERGED (❌)

Changes:
- fixed <array () contains ()?> block with number handling
- fixed <check [every/some] -> ()> block error
- optimized creation of `tryParse`
- removed blockshape patch
- code optimizations/cleanup
- circular JSON visual support
- removed monitor patch
- set/get variable value block
- new "pretty string" option in the `(({}) to (string v))` block
- `allowDropAnywhere` on JSON/Array Blocks for PM