### PR TITLE
Animations.js -- remove unused animations on clone deletion

### DIFF
--- a/extension-code/Animations.js
+++ b/extension-code/Animations.js
@@ -94,7 +94,6 @@
         for (const id in allAnimations) {
           if (!currentIDs.has(id)) {
             delete allAnimations[id];
-            // console.log(`Deleted animations for removed clone: ${id}`);
           }
         }
       };


### PR DESCRIPTION
When clones are made, a copy of all parent animations are passed over to the clone (as seen in the `all existing animations` reporter). This PR makes it so those animations are removed when said clone is deleted, for clarity.

unrelated but idk if it should be version `2.0.14` or just `2.1.0` cause it's a notable addition in my opinion